### PR TITLE
avoid capturing to much whitespace in entity.tag.name

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -70,10 +70,10 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*([.#]?[\w.#_]+ )</string>
+			<string>^\s*([.#]?[\w.#_]+)</string>
 			<key>captures</key>
 			<dict>
-				<key>0</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.tag.slim</string>


### PR DESCRIPTION
in the following the whole intendation before `.bar` was treated as tag name (and so was the whitespace between `.bar` and `[ ... ]`)

```
.foo
    .bar [ ... ]
```
