### PR TITLE
separate symbol from inline-html-tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.cache

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -300,7 +300,7 @@
 		<key>inline-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>\s*([\w.#_-]+:)(?=\s)</string>
+			<string>\s*([\w.#_-]+:)(?=\s[^:'"])</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
hi,
thanks for nice bundle !

I tried to improve syntax highlighting of inline-html-tag.

before:
![st2-slim-before.png](https://github.com/downloads/fukayatsu/ruby-slim-tmbundle/st2-slim-before.png)

after:
![st2-slim-after.png](https://github.com/downloads/fukayatsu/ruby-slim-tmbundle/st2-slim-after.png)
