### PR TITLE
highlighting for whitespace preservation

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -387,7 +387,7 @@
 		<key>rubyline</key>
 		<dict>
 			<key>begin</key>
-			<string>==|=|-</string>
+			<string>=='|='|==|=|-</string>
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>


### PR DESCRIPTION
when using `=='` or `='` the highlighter is looking for a single quoted string.
slim renders a whitespace in this case: https://github.com/stonean/slim/issues/135
