### PR TITLE
Slightly updated comment regular expressions

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -86,13 +86,13 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^ *(/)\s*\S.*$\n?</string>
+			<string>^\s*(/)\s*\S.*$\n?</string>
 			<key>name</key>
 			<string>comment.line.slash.slim</string>
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^( *)(/)\s*$</string>
+			<string>^(\s*)(/)\s*$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>2</key>


### PR DESCRIPTION
Encountered a syntax highlight problem with Sublime Text 2.

Comments `/` were highlighted properly only with(or without) plain spaces preceding them, while indentation is done with tabs. 
Changing spaces with `\s` in some specific regexps did help though.

Merging won't do any harm yet will fix a tiny bug.
