### PR TITLE
Better support for inline HTML tags

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -63,6 +63,29 @@
 			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>^(\s*)(markdown):$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.name.markdown.filter.slim</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(?!(\1\s)|\s*$)</string>
+			<key>name</key>
+			<string>text.markdown.filter.slim</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.md</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Provides support for [inline HTML tag syntax](http://rdoc.info/github/slim-template/slim#Inline_tags) while excluding regular use of the colon character within text. Before these commits, something like `p Lorem ipsum dolor: sit amet.` would result in `dolor: sit` acquiring tag coloring. Not anymore.

Also, inline HTML tags may have attributes with values and tags will remain colored as one would expect as do attribute value strings.

**Caveat:** String coloring is a bit sketchy. Strings get tag coloring in certain situations, which is better than it was before. Inline HTML tags in Slim aren’t practical for long lists of tags with a bunch attributes each, anyway. The last tag in the line (along with its attributes and values) will color reliably, so the common use case:

```
ul
  li.first: a href="#about" title="About Us" target="_top" About Us
  li: a href="#contact" title="Contact Us" target="_top" Contact Us
```

should work like a charm.

**EDIT:** Also, added a commit to define a pattern for markdown, so that nested markdown doesn’t get Slim coloring.
