### PR TITLE
Added multiline ruby syntax highlighting when lines end with comma.

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -269,7 +269,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\\)\s*\n</string>
+			<string>([\\,])\s*\n</string>
 		</dict>
 		<key>delimited-ruby-a</key>
 		<dict>
@@ -490,7 +490,7 @@
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>
-			<string>((do|\{)( \|[^|]+\|)?)$|[^\\]$</string>
+			<string>((do|\{)( \|[^|]+\|)?)$|[^\\,]$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>
@@ -518,11 +518,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>source.ruby.rails</string>
+					<string>#continuation</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#continuation</string>
+					<string>source.ruby.rails</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
As described in the documentation, we don't need backslash for these lines.
http://rdoc.info/gems/slim/file/README.md#Control_code_-

Example

```
= link_to "Long link text here.............",
     long_controller_and_action_names_path

/ Instead of

= link_to "Long link text here.............", \
     long_controller_and_action_names_path

```
