### PR TITLE
Adding .skim as a file format

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>slim</string>
+		<string>skim</string>
 	</array>
 	<key>foldingStartMarker</key>
 	<string>^\s*([-%#\:\.\w\=].*)\s$</string>


### PR DESCRIPTION
Added the .jst.skim file format (https://github.com/jfirebaugh/skim) to the fileTypes array. 

_Skim is the Slim templating engine with embedded CoffeeScript. It compiles to JavaScript templates (.jst), which can then be served by Rails or any other Sprockets-based asset pipeline._
