### PR TITLE
Fix end of Ruby line detection

### DIFF
--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -560,20 +560,7 @@
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>
-			<string>((do|\{)( \|[^|]+\|)?)$|[^\\,]$</string>
-			<key>endCaptures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>source.ruby.embedded.html</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>keyword.control.ruby.start-block</string>
-				</dict>
-			</dict>
+			<string>(?&lt;!\\|,)$</string>
 			<key>name</key>
 			<string>meta.line.ruby.slim</string>
 			<key>patterns</key>


### PR DESCRIPTION
Should fix the problems in #41. Regex is currently excluding the last character in the line from the embedded ruby scope (unless there's a block). This fixes that by using a negative lookbehind, and also simplifies the first part of the expression that doesn't seem to have any purpose except for mangling scope (it's in the HAML bundle as well so I assume it was taken from there).

This still does not apply Ruby syntax scope to the next line if a line ends on a continuation character (`,` or `\`), that looks to be a more complicated fix. However if your color scheme has a different background color for embedded Ruby, it should continue right to the end of the original line, which at least gives some indication.
