### PR TITLE
New Definitions / Resolve Issue Backlog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Do **not** edit [`Ruby Slim.tmLanguage`](Syntaxes/Ruby Slim.tmLanguage) directly. Add patches to [`Ruby Slim.YAML-tmLanguage`](Syntaxes/Ruby Slim.YAML-tmLanguage) and Convert to Property List using the [Sublime Package Dev](https://github.com/SublimeText/PackageDev). Commit both files.

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -1,6 +1,5 @@
 /Comment
 / Space comment
-/ TODO Comment blocks don't highlight https://github.com/slim-template/ruby-slim.tmbundle/issues/38
 / Nested Comment
   Comment
 // Comment
@@ -58,9 +57,6 @@ div constant=nil
 / Ruby attributes
 div dynamic-value=ruby_variable
 div dynamic-value=ruby_variable(with: args, and: 'strings')
-/ TODO https://github.com/slim-template/ruby-slim.tmbundle/issues/47 but also keep in mind https://github.com/slim-template/ruby-slim.tmbundle/issues/53
-div dynamic-value=ruby_variable(with: args,\
-  and: 'strings')
 
 / Attribute wrapping
 div(bracket="attributes" multiple="attributes")
@@ -96,7 +92,6 @@ span> attribute="value" After
 span.class<> Both
 
 / Quote
-/ https://github.com/slim-template/ruby-slim.tmbundle/issues/20
 span This is a ' line with a single quote
 span.klass This is a ' line with a single 'quote'
 span.klass attribute="value" This is a ' line with a single unescaped quote

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -7,7 +7,6 @@
 /! HTML comment
 /[...] IE comment
 
-
 / Root level
 section
 
@@ -98,9 +97,12 @@ span.class<> Both
 
 / Inline
 h2: span Text
-h2: span.class Text
+h2.with-class.second-class: span Text
+h2.with-class.second-class: span.with-class Text
+h2: span.class.class Text
 h2: span.class attributes="value" Text
-.with-class: .and-attribute additional-attribute="value" Text
+.with-class: .single-class data-attribute="value" Text
+.with-class.double-class: .class-and.additional.class attrubute="value" Text here
 
 / Ruby
 - array.each do |item|
@@ -112,6 +114,12 @@ p = app_helper('string', sym: 'value')
   p.class
   p = @hello
   p Regular
+== render 'multiline',
+  with: 'locals',
+  and: :symbols
+== render 'multiline'\
+  with: 'locals',
+  and: :symbols
 
 / Verbatim
 article

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -56,7 +56,8 @@ div constant=nil
 
 / Ruby attributes
 div dynamic-value=ruby_variable
-div dynamic-value=ruby_variable(with: args, and: 'strings')
+/ TODO highlight Ruby variables when they're attribute values
+div dynamic-value=ruby_variable(with: args, and: 'strings') text available here for it is Ruby no more
 
 / Attribute wrapping
 div(bracket="attributes" multiple="attributes")
@@ -112,7 +113,10 @@ h2: span.class attributes="value" Text
 .with-class.double-class: .class-and.additional.class attrubute="value" Text here
 
 / Ruby
+p Words with Ruby reserved words like for or in (for)
 - array.each do |item|
+  - if true
+  - else
 == render 'this', locals: { attribute: 'value' }
 h1 = yield :yield_sym
 = app_helper('string', sym: 'value', class: 'value')

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -76,7 +76,7 @@ div attribute=:value1,value2
 
 / Splats
 #splat*{ 'attribute' => 'value'}
-#splat*{attribute: 'value'}
+#splat *{attribute: 'value'}
 / TODO * is incorrectly colored
 #splat *@variable
 #splat *variable
@@ -94,6 +94,18 @@ div attribute="#{variable if amount > 0} extra-text"
 span< Before
 span> attribute="value" After
 span.class<> Both
+
+/ Quote
+/ https://github.com/slim-template/ruby-slim.tmbundle/issues/20
+span This is a ' line with a single quote
+span.klass This is a ' line with a single 'quote'
+span.klass attribute="value" This is a ' line with a single unescaped quote
+span.klass Additional code shouldn't be highlighted
+
+span This is a " line with a double quote
+span.klass This is a " line with a double "quote"
+span.klass attribute="value" This is a " line with a double unescaped quote
+span.klass Additional code shouldn"t be highlighted
 
 / Inline
 h2: span Text

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -42,6 +42,7 @@ section.-leading-dash
 .underscore_class
 .underscoreunderscore__class
 .-leading-dash
+._leading_underscore
 
 / Attributes
 div quoted="attribute"
@@ -60,6 +61,9 @@ div dynamic-value=ruby_variable
 div dynamic-value=ruby_variable(with: args, and: 'strings') text available here for it is Ruby no more
 
 / Attribute wrapping
+div [attibute="this"]
+/ TODO should support spaces around attribute name and value
+div [ attibute = "this" ] This is text
 div(bracket="attributes" multiple="attributes")
 div[bracket="attributes" multiple="attributes"]
 div [ bracket="attributes" multiple="attributes" ]
@@ -69,11 +73,12 @@ div[bracket="attributes"
 
 / Attribute merging
 div attribute=['value1', 'value2']
+/ TODO highlight attribute merging
 div attribute=:value1,value2
 
 / Splats
 #splat*{ 'attribute' => 'value'}
-#splat *{attribute: 'value'}
+#splat *{attribute: 'value'} Regular text
 / TODO * is incorrectly colored
 #splat *@variable
 #splat *variable
@@ -112,6 +117,11 @@ h2: span.class attributes="value" Text
 .with-class: .single-class data-attribute="value" Text
 .with-class.double-class: .class-and.additional.class attrubute="value" Text here
 
+/ XML
+loc:url .this is="attr" this is text Title
+/ TODO second colon should highlight as a punctuation.definition.tag.end.slim
+loc:url: .this is="attr" this is text Title
+
 / Ruby
 p Words with Ruby reserved words like for or in (for)
 - array.each do |item|
@@ -148,10 +158,10 @@ article
 
 / HTML
 
-/ TODO HTML tags don't highlight at root level or within elements
-.inline Text <normal html_tag="this"><and this="this"> Text
+/ TODO HTML attributes with underscores don't highlight properly - might be something with the text.html source?
+.inline Text <normal html_underscore_value="value" normal="attribute" html-dash-attribute="value"><and this="this"> Text</normal>
 | <tag dash-attribute="this"><tag:with:colon this="this">
-<normal class="html-tag">
+<normal class="html-tag" underscore_attribute="value" normal-dash-attribute="value">
 
 / Embedded Engines
 

--- a/Demo/demo.slim
+++ b/Demo/demo.slim
@@ -1,0 +1,184 @@
+/Comment
+/ Space comment
+/ TODO Comment blocks don't highlight https://github.com/slim-template/ruby-slim.tmbundle/issues/38
+/ Nested Comment
+  Comment
+// Comment
+/! HTML comment
+/[...] IE comment
+
+
+/ Root level
+section
+
+/ Element with integer
+h2
+
+section
+  #nested
+    .selectors
+
+/ Classes and IDs
+section.class
+section.two.classes
+section#id
+section#id.class
+section.class#id
+section.class#id.class
+section.dash-class
+section.dashdash--class
+section.underscore_class
+section.underscoreunderscore__class
+section.-leading-dash
+
+/ ID and Class Shortcut
+
+.class
+.two.classes
+#id
+#id.class
+.class#id
+.class#id.class
+.dash-class
+.dashdash--class
+.underscore_class
+.underscoreunderscore__class
+.-leading-dash
+
+/ Attributes
+div quoted="attribute"
+div quoted="attribute" single='quoted'
+div dash-attribute='attribute'
+div.class with-attribute="attribute"
+div.class with-attribute="attribute\
+  multiple lines"
+div constant=true
+div constant=false
+div constant=nil
+
+/ Ruby attributes
+div dynamic-value=ruby_variable
+div dynamic-value=ruby_variable(with: args, and: 'strings')
+/ TODO https://github.com/slim-template/ruby-slim.tmbundle/issues/47 but also keep in mind https://github.com/slim-template/ruby-slim.tmbundle/issues/53
+div dynamic-value=ruby_variable(with: args,\
+  and: 'strings')
+
+/ Attribute wrapping
+div(bracket="attributes" multiple="attributes")
+div[bracket="attributes" multiple="attributes"]
+div [ bracket="attributes" multiple="attributes" ]
+/ TODO line-break attribute wrapping doesn't hold
+div[bracket="attributes"
+  multiple="attributes"]
+
+/ Attribute merging
+div attribute=['value1', 'value2']
+div attribute=:value1,value2
+
+/ Splats
+#splat*{ 'attribute' => 'value'}
+#splat*{attribute: 'value'}
+/ TODO * is incorrectly colored
+#splat *@variable
+#splat *variable
+
+/ Dynamic tags
+*{ tag: 'span' }
+
+/ Interpolation
+div #{variable if amount > 0} Extra text
+div Extra #{variable if amount > 0} text
+div Extra text #{variable if amount > 0}
+div attribute="#{variable if amount > 0} extra-text"
+
+/ Whitespace
+span< Before
+span> attribute="value" After
+span.class<> Both
+
+/ Inline
+h2: span Text
+h2: span.class Text
+h2: span.class attributes="value" Text
+.with-class: .and-attribute additional-attribute="value" Text
+
+/ Ruby
+- array.each do |item|
+== render 'this', locals: { attribute: 'value' }
+h1 = yield :yield_sym
+= app_helper('string', sym: 'value', class: 'value')
+p = app_helper('string', sym: 'value')
+- content_for :hello_slim do
+  p.class
+  p = @hello
+  p Regular
+
+/ Verbatim
+article
+  | Opening text
+
+/ TODO https://github.com/slim-template/ruby-slim.tmbundle/issues/59
+|
+  Other text
+  Other text
+
+- if true
+  | console.log("foo");
+- else
+  | console.log("bar");
+
+/ HTML
+
+/ TODO HTML tags don't highlight at root level or within elements
+.inline Text <normal html_tag="this"><and this="this"> Text
+| <tag dash-attribute="this"><tag:with:colon this="this">
+<normal class="html-tag">
+
+/ Embedded Engines
+
+ruby:
+  blank = []
+  @instance.each do |item|
+    blank << item.name
+  end
+  # Comment
+  blank = @instance.map(&:name)
+
+javascript:
+  (function() {
+    console.log('hello world');
+  });
+
+coffee:
+  anon: ->
+    console.log 'hello world'
+
+scss:
+  .hello:before {
+    color: $world
+  }
+
+css:
+  .hello:before {
+    content: 'world'
+  }
+
+less:
+  .hello:before {
+    content: @world
+  }
+
+sass:
+  .hello
+    content: $world
+
+markdown:
+  # Hello
+  **World**
+
+erb:
+  <%= hello_world if hello_world.present? %>
+
+---
+front_matter: present
+---

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the [Textmate](http://macromates.com/)/[Sublime Text](http://www.sublime
     cd ~/Library/Application\ Support/TextMate/Managed/Bundles/
     git clone git://github.com/slim-template/ruby-slim.tmbundle.git Ruby-Slim.tmbundle
 
-### Sublime Text 2
+### Sublime Text 2 & 3
 
 Please install it via [Package Control](http://wbond.net/sublime_packages/package_control).
 

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -150,7 +150,6 @@ patterns:
     patterns:
     - include: '#tag-class-id-attribute'
     - include: '#normal-html-tag'
-  - include: '#tag-class-id-attribute'
   - begin: (\*\{)(?=.*\}|.*\|\s*$)
     end: (\})|$|^(?!.*\|\s*$)
     name: source.ruby.embedded.slim
@@ -163,6 +162,7 @@ patterns:
         name: punctuation.section.embedded.ruby
     patterns:
     - include: '#embedded-ruby'
+  - include: '#tag-class-id-attribute'
   - include: '#rubyline'
   - match: /
     name: punctuation.terminator.tag.slim
@@ -231,7 +231,7 @@ repository:
     end: \s|\w$
     name: source.ruby.embedded.html
   normal-html-tag:
-    begin: ([\w.#_-]+)=(true|false|nil)?
+    begin: ([\w.#_-]+)=(?!\s)(true|false|nil)?
     captures:
       '1':
         name: entity.other.attribute-name.event.slim
@@ -251,7 +251,7 @@ repository:
     patterns:
     - include: '#tag-stuff'
   rubyline:
-    begin: (==|=)(<>|><|<'|'<|<|>|')?|-
+    begin: (==|=)(<>|><|<'|'<|<|>)?|-
     contentName: source.ruby.embedded.slim
     end: (?<!\\|,|,\n|\\\n)$
     name: meta.line.ruby.slim
@@ -262,7 +262,7 @@ repository:
     - include: '#continuation'
     - include: source.ruby.rails
   string-double-quoted:
-    begin: (?<==)"
+    begin: (")(?=.*")
     beginCaptures:
       '0':
         name: punctuation.definition.string.begin.html
@@ -276,7 +276,7 @@ repository:
     - include: '#embedded-ruby'
     - include: '#entities'
   string-single-quoted:
-    begin: (?<==)'
+    begin: (')(?=.*')
     beginCaptures:
       '0':
         name: punctuation.definition.string.begin.html
@@ -296,22 +296,9 @@ repository:
         name: punctuation.separator.key-value.html
       '2':
         name: entity.other.attribute-name.html
-  tag-id-attribute:
-    begin: \b(id)\b\s*(=)
-    captures:
-      '1':
-        name: entity.other.attribute-name.id.html
-      '2':
-        name: punctuation.separator.key-value.html
-    end: (?<='|")
-    name: meta.attribute-with-value.id.html
-    patterns:
-    - include: '#string-double-quoted'
-    - include: '#string-single-quoted'
   tag-stuff:
     patterns:
     - include: '#normal-html-tag'
-    - include: '#tag-id-attribute'
     - include: '#interpolated-ruby'
     - include: '#delimited-ruby-a'
     - include: '#delimited-ruby-b'

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -1,0 +1,316 @@
+fileTypes:
+- slim
+- skim
+foldingStartMarker: ^\s*([-%#\:\.\w\=].*)\s$
+foldingStopMarker: ^\s*$
+keyEquivalent: ^~S
+name: Ruby Slim
+patterns:
+- begin: ^(\s*)(ruby):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.ruby.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.ruby.filter.slim
+  patterns:
+  - include: source.ruby
+
+- begin: ^(\s*)(javascript):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.javascript.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.javascript.filter.slim
+  patterns:
+  - include: source.js
+
+- begin: ^(---)\s*\n
+  beginCaptures:
+    '1':
+      name: storage.frontmatter.slim
+  end: ^(---)\s*\n
+  endCaptures:
+    '1':
+      name: storage.frontmatter.slim
+  name: source.yaml.meta.slim
+  patterns:
+  - include: source.yaml
+
+- begin: ^(\s*)(coffee):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.coffeescript.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.coffeescript.filter.slim
+  patterns:
+  - include: source.coffee
+
+- begin: ^(\s*)(markdown):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.markdown.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.markdown.filter.slim
+  patterns:
+  - include: source.md
+
+- begin: ^(\s*)(css):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.css.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.css.filter.slim
+  patterns:
+  - include: source.css
+
+- begin: ^(\s*)(sass):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.sass.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.sass.filter.slim
+  patterns:
+  - include: source.sass
+
+- begin: ^(\s*)(scss):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.scss.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.scss.filter.slim
+  patterns:
+  - include: source.scss
+
+- begin: ^(\s*)(less):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.less.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.less.filter.slim
+  patterns:
+  - include: source.less
+
+- begin: ^(\s*)(erb):$
+  beginCaptures:
+    '2':
+      name: constant.language.name.erb.filter.slim
+  end: ^(?!(\1\s)|\s*$)
+  name: text.erb.filter.slim
+  patterns:
+  - include: source.erb
+
+- captures:
+    '1':
+      name: punctuation.definition.prolog.slim
+  match: ^(! )($|\s.*)
+  name: meta.prolog.slim
+
+- captures:
+    '1':
+      name: punctuation.section.comment.slim
+  match: ^\s*(/)\s*\S.*$\n?
+  name: comment.line.slash.slim
+
+- begin: ^(\s*)(/)\s*$
+  beginCaptures:
+    '1':
+      name: punctuation.section.comment.slim
+  end: ^(?!\1  )
+  name: comment.block.slim
+  patterns:
+  - include: text.slim
+
+- begin: (?==+|-|~)
+  end: $
+  patterns:
+  - include: '#rubyline'
+
+- include: '#normal-html-tag'
+- include: '#embedded-ruby'
+- include: '#slim-declaration'
+
+- begin: ^\s*(\.|#|[a-zA-Z0-9-_]+)([a-zA-Z0-9-_]+)?(?:(:)\s([a-zA-Z0-9-_]+)?)?
+  end: $|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])
+  name: meta.tag.any.slim
+  comment: 1 - dot or hash; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or #); 3 - colon; 4 - Any combination of word, number, dash or underscore
+  captures:
+    '1':
+      name: entity.name.tag.slim
+    '2':
+      name: entity.other.attribute-name.event.slim
+    '3':
+      name: punctuation.definition.tag.end.slim
+    '4':
+      name: entity.name.tag.slim
+
+  patterns:
+  - include: '#tag-class-id-attribute'
+  - begin: (\*\{)(?=.*\}|.*\|\s*$)
+    end: (\})|$|^(?!.*\|\s*$)
+    name: source.ruby.embedded.slim
+    comment: Splat attributes
+    beginCaptures:
+      '1':
+        name: punctuation.section.embedded.ruby
+    endCaptures:
+      '1':
+        name: punctuation.section.embedded.ruby
+    patterns:
+    - include: '#embedded-ruby'
+  - include: '#rubyline'
+  - match: /
+    name: punctuation.terminator.tag.slim
+
+- captures:
+    '1':
+      name: meta.escape.slim
+  match: ^\s*(\\.)
+
+- begin: ^\s*(?=\||')
+  end: $
+
+  patterns:
+  - include: '#embedded-ruby'
+  - include: text.html.basic
+
+repository:
+  continuation:
+    captures:
+      '1':
+        name: punctuation.separator.continuation.slim
+    match: ([\\,])\s*\n
+  delimited-ruby-a:
+    begin: =\(
+    end: \)(?=( \w|$))
+    name: source.ruby.embedded.slim
+    patterns:
+    - include: source.ruby.rails
+  delimited-ruby-b:
+    begin: =\[
+    end: \](?=( \w|$))
+    name: source.ruby.embedded.slim
+    patterns:
+    - include: source.ruby.rails
+  delimited-ruby-c:
+    begin: =\{
+    end: \}(?=( \w|$))
+    name: source.ruby.embedded.slim
+    patterns:
+    - include: source.ruby.rails
+  embedded-ruby:
+    begin: (?<!\\)#\{{1,2}
+    beginCaptures:
+      '0':
+        name: punctuation.section.embedded.ruby
+    end: \}{1,2}
+    endCaptures:
+      '0':
+        name: punctuation.section.embedded.ruby
+    name: source.ruby.embedded.html
+    patterns:
+    - include: source.ruby.rails
+  entities:
+    patterns:
+    - captures:
+        '1':
+          name: punctuation.definition.entity.html
+        '3':
+          name: punctuation.definition.entity.html
+      match: (&)([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+)(;)
+      name: constant.character.entity.html
+    - match: '&'
+      name: invalid.illegal.bad-ampersand.html
+  interpolated-ruby:
+    begin: =(?=\b)
+    end: \s|\w$
+    name: source.ruby.embedded.html
+  normal-html-tag:
+    begin: ([\w.#_-]+)=(true|false|nil)?
+    captures:
+      '1':
+        name: entity.other.attribute-name.event.slim
+      '2':
+        name: constant.language.slim
+    end: $
+    patterns:
+    - include: '#tag-stuff'
+    - include: '#string-double-quoted'
+    - include: '#string-single-quoted'
+  normal-inline-html-tag:
+    begin: ([\w.#_-]+)
+    captures:
+      '1':
+        name: entity.name.tag.slim
+    end: $
+    patterns:
+    - include: '#tag-stuff'
+  rubyline:
+    begin: (==|=)(<>|><|<'|'<|<|>|')?|-
+    contentName: source.ruby.embedded.slim
+    end: (?<!\\|,)$
+    name: meta.line.ruby.slim
+    patterns:
+    - comment: Hack to let ruby comments work in this context properly
+      match: '#.*$'
+      name: comment.line.number-sign.ruby
+    - include: '#continuation'
+    - include: source.ruby.rails
+  string-double-quoted:
+    begin: '"'
+    beginCaptures:
+      '0':
+        name: punctuation.definition.string.begin.html
+    contentName: meta.toc-list.id.html
+    end: '"'
+    endCaptures:
+      '0':
+        name: punctuation.definition.string.end.html
+    name: string.quoted.double.html
+    patterns:
+    - include: '#embedded-ruby'
+    - include: '#entities'
+  string-single-quoted:
+    begin: ''''
+    beginCaptures:
+      '0':
+        name: punctuation.definition.string.begin.html
+    contentName: meta.toc-list.id.html
+    end: ''''
+    endCaptures:
+      '0':
+        name: punctuation.definition.string.end.html
+    name: string.quoted.single.html
+    patterns:
+    - include: '#embedded-ruby'
+    - include: '#entities'
+  tag-class-id-attribute:
+    match: (\.|#)([\w\d-_]+)
+    captures:
+      '1':
+        name: punctuation.separator.key-value.html
+      '2':
+        name: entity.other.attribute-name.html
+  tag-id-attribute:
+    begin: \b(id)\b\s*(=)
+    captures:
+      '1':
+        name: entity.other.attribute-name.id.html
+      '2':
+        name: punctuation.separator.key-value.html
+    end: (?<='|")
+    name: meta.attribute-with-value.id.html
+    patterns:
+    - include: '#string-double-quoted'
+    - include: '#string-single-quoted'
+  tag-stuff:
+    patterns:
+    - include: '#normal-html-tag'
+    - include: '#tag-id-attribute'
+    - include: '#interpolated-ruby'
+    - include: '#delimited-ruby-a'
+    - include: '#delimited-ruby-b'
+    - include: '#delimited-ruby-c'
+    - include: '#rubyline'
+    - include: '#embedded-ruby'
+scopeName: text.slim
+uuid: 36302CC1-1E76-4910-B7B6-F1915EBBA0D3

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -105,20 +105,18 @@ patterns:
   match: ^(! )($|\s.*)
   name: meta.prolog.slim
 
-- captures:
-    '1':
-      name: punctuation.section.comment.slim
-  match: ^\s*(/)\s*\S.*$\n?
-  name: comment.line.slash.slim
-
-- begin: ^(\s*)(/)\s*$
+- begin: ^(\s*)(/)\s*.*$
   beginCaptures:
     '1':
       name: punctuation.section.comment.slim
   end: ^(?!\1  )
   name: comment.block.slim
-  patterns:
-  - include: text.slim
+
+- captures:
+    '1':
+      name: punctuation.section.comment.slim
+  match: ^\s*(/)\s*\S.*$\n?
+  name: comment.line.slash.slim
 
 - begin: (?==+|-|~)
   end: $

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -118,7 +118,12 @@ patterns:
   match: ^\s*(/)\s*\S.*$\n?
   name: comment.line.slash.slim
 
-- begin: (?==+|-|~)
+- begin: ^\s*(?=-)
+  end: $
+  patterns:
+  - include: '#rubyline'
+
+- begin: (?==+|~)
   end: $
   patterns:
   - include: '#rubyline'
@@ -231,25 +236,17 @@ repository:
     end: \s|\w$
     name: source.ruby.embedded.html
   normal-html-tag:
-    begin: ([\w.#_-]+)=(?!\s)(true|false|nil)?
+    begin: ([\w.#_-]+)=(?!\s)(true|false|nil)?(?=\(|\{)?
     captures:
       '1':
         name: entity.other.attribute-name.event.slim
       '2':
         name: constant.language.slim
-    end: $
+    end: \}|\)|$
     patterns:
     - include: '#tag-stuff'
     - include: '#string-double-quoted'
     - include: '#string-single-quoted'
-  normal-inline-html-tag:
-    begin: ([\w.#_-]+)
-    captures:
-      '1':
-        name: entity.name.tag.slim
-    end: $
-    patterns:
-    - include: '#tag-stuff'
   rubyline:
     begin: (==|=)(<>|><|<'|'<|<|>)?|-
     contentName: source.ruby.embedded.slim

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -127,23 +127,31 @@ patterns:
 
 - include: '#normal-html-tag'
 - include: '#embedded-ruby'
-- include: '#slim-declaration'
 
-- begin: ^\s*(\.|#|[a-zA-Z0-9-_]+)([a-zA-Z0-9-_]+)?(?:(:)\s([a-zA-Z0-9-_]+)?)?
-  end: $|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])
-  name: meta.tag.any.slim
-  comment: 1 - dot or hash; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or #); 3 - colon; 4 - Any combination of word, number, dash or underscore
+- begin: ^\s*(\.|#|[a-zA-Z0-9]+)([\w-]+)?
+  end: $|(?!\.|#|=|:|-|~|/|\}|\]|\*|\s?[\*\{])
+  name: meta.tag
+  comment: 1 - dot OR hash OR any combination of word, number; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or #)
   captures:
     '1':
       name: entity.name.tag.slim
     '2':
       name: entity.other.attribute-name.event.slim
-    '3':
-      name: punctuation.definition.tag.end.slim
-    '4':
-      name: entity.name.tag.slim
 
   patterns:
+  - begin: (:\s)(\.|#|[a-zA-Z0-9]+)([\w-]+)?
+    end: $|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])
+    comment: Inline HTML / 1 - colon; 2 - dot OR hash OR any combination of word, number; 3 - OPTIONAL any combination of word, number, dash or underscore (following a . or #)
+    captures:
+      '1':
+        name: punctuation.definition.tag.end.slim
+      '2':
+        name: entity.name.tag.slim
+      '3':
+        name: entity.other.attribute-name.event.slim
+    patterns:
+    - include: '#tag-class-id-attribute'
+    - include: '#normal-html-tag'
   - include: '#tag-class-id-attribute'
   - begin: (\*\{)(?=.*\}|.*\|\s*$)
     end: (\})|$|^(?!.*\|\s*$)
@@ -247,7 +255,7 @@ repository:
   rubyline:
     begin: (==|=)(<>|><|<'|'<|<|>|')?|-
     contentName: source.ruby.embedded.slim
-    end: (?<!\\|,)$
+    end: (?<!\\|,|,\n|\\\n)$
     name: meta.line.ruby.slim
     patterns:
     - comment: Hack to let ruby comments work in this context properly

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -264,7 +264,7 @@ repository:
     - include: '#continuation'
     - include: source.ruby.rails
   string-double-quoted:
-    begin: '"'
+    begin: (?<==)"
     beginCaptures:
       '0':
         name: punctuation.definition.string.begin.html
@@ -278,7 +278,7 @@ repository:
     - include: '#embedded-ruby'
     - include: '#entities'
   string-single-quoted:
-    begin: ''''
+    begin: (?<==)'
     beginCaptures:
       '0':
         name: punctuation.definition.string.begin.html

--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -128,7 +128,7 @@ patterns:
   patterns:
   - include: '#rubyline'
 
-- include: '#normal-html-tag'
+- include: '#tag-attribute'
 - include: '#embedded-ruby'
 
 - begin: ^\s*(\.|#|[a-zA-Z0-9]+)([\w-]+)?
@@ -142,6 +142,11 @@ patterns:
       name: entity.other.attribute-name.event.slim
 
   patterns:
+  - begin: (:[\w\d]+)+
+    end: $|\s
+    comment: XML
+    name: entity.name.tag.slim
+
   - begin: (:\s)(\.|#|[a-zA-Z0-9]+)([\w-]+)?
     end: $|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])
     comment: Inline HTML / 1 - colon; 2 - dot OR hash OR any combination of word, number; 3 - OPTIONAL any combination of word, number, dash or underscore (following a . or #)
@@ -153,8 +158,8 @@ patterns:
       '3':
         name: entity.other.attribute-name.event.slim
     patterns:
-    - include: '#tag-class-id-attribute'
-    - include: '#normal-html-tag'
+    - include: '#root-class-id-tag'
+    - include: '#tag-attribute'
   - begin: (\*\{)(?=.*\}|.*\|\s*$)
     end: (\})|$|^(?!.*\|\s*$)
     name: source.ruby.embedded.slim
@@ -167,7 +172,7 @@ patterns:
         name: punctuation.section.embedded.ruby
     patterns:
     - include: '#embedded-ruby'
-  - include: '#tag-class-id-attribute'
+  - include: '#root-class-id-tag'
   - include: '#rubyline'
   - match: /
     name: punctuation.terminator.tag.slim
@@ -182,6 +187,12 @@ patterns:
 
   patterns:
   - include: '#embedded-ruby'
+  - include: text.html.basic
+
+- begin: (?=<[\w\d\:]+)
+  end: $|\/\>
+  comment: Inline and root-level HTML tags
+  patterns:
   - include: text.html.basic
 
 repository:
@@ -235,8 +246,8 @@ repository:
     begin: =(?=\b)
     end: \s|\w$
     name: source.ruby.embedded.html
-  normal-html-tag:
-    begin: ([\w.#_-]+)=(?!\s)(true|false|nil)?(?=\(|\{)?
+  tag-attribute:
+    begin: ([\w.#_-]+)=(?!\s)(true|false|nil)?(\s*\(|\{)?
     captures:
       '1':
         name: entity.other.attribute-name.event.slim
@@ -286,8 +297,8 @@ repository:
     patterns:
     - include: '#embedded-ruby'
     - include: '#entities'
-  tag-class-id-attribute:
-    match: (\.|#)([\w\d-_]+)
+  root-class-id-tag:
+    match: (\.|#)([\w\d\-]+)
     captures:
       '1':
         name: punctuation.separator.key-value.html
@@ -295,7 +306,7 @@ repository:
         name: entity.other.attribute-name.html
   tag-stuff:
     patterns:
-    - include: '#normal-html-tag'
+    - include: '#tag-attribute'
     - include: '#interpolated-ruby'
     - include: '#delimited-ruby-a'
     - include: '#delimited-ruby-b'

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -270,22 +270,8 @@
 			<string>meta.prolog.slim</string>
 		</dict>
 		<dict>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.section.comment.slim</string>
-				</dict>
-			</dict>
-			<key>match</key>
-			<string>^\s*(/)\s*\S.*$\n?</string>
-			<key>name</key>
-			<string>comment.line.slash.slim</string>
-		</dict>
-		<dict>
 			<key>begin</key>
-			<string>^(\s*)(/)\s*$</string>
+			<string>^(\s*)(/)\s*.*$</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -298,13 +284,20 @@
 			<string>^(?!\1  )</string>
 			<key>name</key>
 			<string>comment.block.slim</string>
-			<key>patterns</key>
-			<array>
+		</dict>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
 				<dict>
-					<key>include</key>
-					<string>text.slim</string>
+					<key>name</key>
+					<string>punctuation.section.comment.slim</string>
 				</dict>
-			</array>
+			</dict>
+			<key>match</key>
+			<string>^\s*(/)\s*\S.*$\n?</string>
+			<key>name</key>
+			<string>comment.line.slash.slim</string>
 		</dict>
 		<dict>
 			<key>begin</key>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -375,7 +375,7 @@
 					<key>comment</key>
 					<string>Inline HTML / 1 - colon; 2 - dot OR hash OR any combination of word, number; 3 - OPTIONAL any combination of word, number, dash or underscore (following a . or</string>
 					<key>end</key>
-					<string>$|(?!\.|#|=|:|-|~|/|\}|\]|\*|\s?[\*\{])</string>
+					<string>$|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])</string>
 					<key>patterns</key>
 					<array>
 						<dict>
@@ -692,7 +692,7 @@
 		<key>string-double-quoted</key>
 		<dict>
 			<key>begin</key>
-			<string>"</string>
+			<string>(?&lt;==)"</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -730,7 +730,7 @@
 		<key>string-single-quoted</key>
 		<dict>
 			<key>begin</key>
-			<string>'</string>
+			<string>(?&lt;==)'</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -301,7 +301,20 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(?==+|-|~)</string>
+			<string>^\s*(?=-)</string>
+			<key>end</key>
+			<string>$</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#rubyline</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(?==+|~)</string>
 			<key>end</key>
 			<string>$</string>
 			<key>patterns</key>
@@ -416,11 +429,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#tag-class-id-attribute</string>
+					<string>#rubyline</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#rubyline</string>
+					<string>#tag-class-id-attribute</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -598,7 +611,7 @@
 		<key>normal-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w.#_-]+)=(?!\s)(true|false|nil)?</string>
+			<string>([\w.#_-]+)=(?!\s)(true|false|nil)?(?=\(|\{)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -613,7 +626,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>$</string>
+			<string>\}|\)|$</string>
 			<key>patterns</key>
 			<array>
 				<dict>
@@ -627,28 +640,6 @@
 				<dict>
 					<key>include</key>
 					<string>#string-single-quoted</string>
-				</dict>
-			</array>
-		</dict>
-		<key>normal-inline-html-tag</key>
-		<dict>
-			<key>begin</key>
-			<string>([\w.#_-]+)</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>$</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#tag-stuff</string>
 				</dict>
 			</array>
 		</dict>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -328,12 +328,8 @@
 			<string>#embedded-ruby</string>
 		</dict>
 		<dict>
-			<key>include</key>
-			<string>#slim-declaration</string>
-		</dict>
-		<dict>
 			<key>begin</key>
-			<string>^\s*(\.|#|[a-zA-Z0-9-_]+)([a-zA-Z0-9-_]+)?(?:(:)\s([a-zA-Z0-9-_]+)?)?</string>
+			<string>^\s*(\.|#|[a-zA-Z0-9]+)([\w-]+)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -346,25 +342,52 @@
 					<key>name</key>
 					<string>entity.other.attribute-name.event.slim</string>
 				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.definition.tag.end.slim</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
 			</dict>
 			<key>comment</key>
-			<string>1 - dot or hash; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or</string>
+			<string>1 - dot OR hash OR any combination of word, number; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or</string>
 			<key>end</key>
-			<string>$|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])</string>
+			<string>$|(?!\.|#|=|:|-|~|/|\}|\]|\*|\s?[\*\{])</string>
 			<key>name</key>
-			<string>meta.tag.any.slim</string>
+			<string>meta.tag</string>
 			<key>patterns</key>
 			<array>
+				<dict>
+					<key>begin</key>
+					<string>(:\s)(\.|#|[a-zA-Z0-9]+)([\w-]+)?</string>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.definition.tag.end.slim</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>entity.name.tag.slim</string>
+						</dict>
+						<key>3</key>
+						<dict>
+							<key>name</key>
+							<string>entity.other.attribute-name.event.slim</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Inline HTML / 1 - colon; 2 - dot OR hash OR any combination of word, number; 3 - OPTIONAL any combination of word, number, dash or underscore (following a . or</string>
+					<key>end</key>
+					<string>$|(?!\.|#|=|:|-|~|/|\}|\]|\*|\s?[\*\{])</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>#tag-class-id-attribute</string>
+						</dict>
+						<dict>
+							<key>include</key>
+							<string>#normal-html-tag</string>
+						</dict>
+					</array>
+				</dict>
 				<dict>
 					<key>include</key>
 					<string>#tag-class-id-attribute</string>
@@ -643,7 +666,7 @@
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>
-			<string>(?&lt;!\\|,)$</string>
+			<string>(?&lt;!\\|,|,\n|\\\n)$</string>
 			<key>name</key>
 			<string>meta.line.ruby.slim</string>
 			<key>patterns</key>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -205,7 +205,53 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>source.sass</string>
+					<string>source.scss</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^(\s*)(less):$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.name.less.filter.slim</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(?!(\1\s)|\s*$)</string>
+			<key>name</key>
+			<string>text.less.filter.slim</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.less</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>^(\s*)(erb):$</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.name.erb.filter.slim</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>^(?!(\1\s)|\s*$)</string>
+			<key>name</key>
+			<string>text.erb.filter.slim</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>source.erb</string>
 				</dict>
 			</array>
 		</dict>
@@ -224,11 +270,25 @@
 			<string>meta.prolog.slim</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.comment.slim</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>^\s*(/)\s*\S.*$\n?</string>
+			<key>name</key>
+			<string>comment.line.slash.slim</string>
+		</dict>
+		<dict>
 			<key>begin</key>
-			<string>^(\s*)(/)\s*</string>
+			<string>^(\s*)(/)\s*$</string>
 			<key>beginCaptures</key>
 			<dict>
-				<key>2</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>punctuation.section.comment.slim</string>
@@ -248,7 +308,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(?===|=|-|~)</string>
+			<string>(?==+|-|~)</string>
 			<key>end</key>
 			<string>$</string>
 			<key>patterns</key>
@@ -261,10 +321,6 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#inline-html-tag</string>
-		</dict>
-		<dict>
-			<key>include</key>
 			<string>#normal-html-tag</string>
 		</dict>
 		<dict>
@@ -272,11 +328,15 @@
 			<string>#embedded-ruby</string>
 		</dict>
 		<dict>
+			<key>include</key>
+			<string>#slim-declaration</string>
+		</dict>
+		<dict>
 			<key>begin</key>
-			<string>^\s*((\w*)(?:[.#_-]*\w+)*)\s*</string>
+			<string>^\s*(\.|#|[a-zA-Z0-9-_]+)([a-zA-Z0-9-_]+)?(?:(:)\s([a-zA-Z0-9-_]+)?)?</string>
 			<key>captures</key>
 			<dict>
-				<key>0</key>
+				<key>1</key>
 				<dict>
 					<key>name</key>
 					<string>entity.name.tag.slim</string>
@@ -284,48 +344,61 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.tag-name.slim</string>
+					<string>entity.other.attribute-name.event.slim</string>
+				</dict>
+				<key>3</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.tag.end.slim</string>
+				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.tag.slim</string>
 				</dict>
 			</dict>
+			<key>comment</key>
+			<string>1 - dot or hash; 2 - OPTIONAL any combination of word, number, dash or underscore (following a . or</string>
 			<key>end</key>
-			<string>$|(?!\.|#|\{|\[|=|-|~|/)</string>
+			<string>$|(?!\.|#|=|-|~|/|\}|\]|\*|\s?[\*\{])</string>
+			<key>name</key>
+			<string>meta.tag.any.slim</string>
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>begin</key>
-					<string>\{(?=.*\}|.*\|\s*$)</string>
-					<key>end</key>
-					<string>\}|$|^(?!.*\|\s*$)</string>
-					<key>name</key>
-					<string>meta.section.attributes.slim</string>
-					<key>patterns</key>
-					<array>
-						<dict>
-							<key>include</key>
-							<string>source.ruby.rails</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#continuation</string>
-						</dict>
-					</array>
+					<key>include</key>
+					<string>#tag-class-id-attribute</string>
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>\[(?=.*\]|.*\|\s*$)</string>
+					<string>(\*\{)(?=.*\}|.*\|\s*$)</string>
+					<key>beginCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.ruby</string>
+						</dict>
+					</dict>
+					<key>comment</key>
+					<string>Splat attributes</string>
 					<key>end</key>
-					<string>\]|$|^(?!.*\|\s*$)</string>
+					<string>(\})|$|^(?!.*\|\s*$)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.ruby</string>
+						</dict>
+					</dict>
 					<key>name</key>
-					<string>meta.section.object.slim</string>
+					<string>source.ruby.embedded.slim</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>include</key>
-							<string>source.ruby.rails</string>
-						</dict>
-						<dict>
-							<key>include</key>
-							<string>#continuation</string>
+							<string>#embedded-ruby</string>
 						</dict>
 					</array>
 				</dict>
@@ -497,62 +570,6 @@
 				</dict>
 			</array>
 		</dict>
-		<key>inline-html-tag</key>
-		<dict>
-			<key>begin</key>
-			<string>^(\s*([\w.#_-]+( [\w.#_-]+=(".*?"))*: )*)([\w.#_-]+( [\w.#_-]+=(".*?"))*:)(?=\s)</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-				<key>3</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-				<key>4</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.double.html</string>
-				</dict>
-				<key>5</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-				<key>6</key>
-				<dict>
-					<key>name</key>
-					<string>entity.name.tag.slim</string>
-				</dict>
-				<key>7</key>
-				<dict>
-					<key>name</key>
-					<string>string.quoted.double.html</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>$</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#normal-inline-html-tag</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#tag-stuff</string>
-				</dict>
-			</array>
-		</dict>
 		<key>interpolated-ruby</key>
 		<dict>
 			<key>begin</key>
@@ -565,13 +582,18 @@
 		<key>normal-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w.#_-]+=)</string>
+			<string>([\w.#_-]+)=(true|false|nil)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.name.tag.slim</string>
+					<string>entity.other.attribute-name.event.slim</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.language.slim</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -621,7 +643,7 @@
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>
-			<string>(?&lt;!\\|,|\n)$</string>
+			<string>(?&lt;!\\|,)$</string>
 			<key>name</key>
 			<string>meta.line.ruby.slim</string>
 			<key>patterns</key>
@@ -720,6 +742,24 @@
 				</dict>
 			</array>
 		</dict>
+		<key>tag-class-id-attribute</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.key-value.html</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.other.attribute-name.html</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(\.|#)([\w\d-_]+)</string>
+		</dict>
 		<key>tag-id-attribute</key>
 		<dict>
 			<key>begin</key>
@@ -757,10 +797,6 @@
 		<dict>
 			<key>patterns</key>
 			<array>
-				<dict>
-					<key>include</key>
-					<string>#inline-html-tag</string>
-				</dict>
 				<dict>
 					<key>include</key>
 					<string>#normal-html-tag</string>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -327,7 +327,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#normal-html-tag</string>
+			<string>#tag-attribute</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -359,6 +359,16 @@
 			<array>
 				<dict>
 					<key>begin</key>
+					<string>(:[\w\d]+)+</string>
+					<key>comment</key>
+					<string>XML</string>
+					<key>end</key>
+					<string>$|\s</string>
+					<key>name</key>
+					<string>entity.name.tag.slim</string>
+				</dict>
+				<dict>
+					<key>begin</key>
 					<string>(:\s)(\.|#|[a-zA-Z0-9]+)([\w-]+)?</string>
 					<key>captures</key>
 					<dict>
@@ -386,11 +396,11 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>#tag-class-id-attribute</string>
+							<string>#root-class-id-tag</string>
 						</dict>
 						<dict>
 							<key>include</key>
-							<string>#normal-html-tag</string>
+							<string>#tag-attribute</string>
 						</dict>
 					</array>
 				</dict>
@@ -429,11 +439,11 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#rubyline</string>
+					<string>#root-class-id-tag</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#tag-class-id-attribute</string>
+					<string>#rubyline</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -466,6 +476,21 @@
 					<key>include</key>
 					<string>#embedded-ruby</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>text.html.basic</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
+			<string>(?=&lt;[\w\d\:]+)</string>
+			<key>comment</key>
+			<string>Inline and root-level HTML tags</string>
+			<key>end</key>
+			<string>$|\/\&gt;</string>
+			<key>patterns</key>
+			<array>
 				<dict>
 					<key>include</key>
 					<string>text.html.basic</string>
@@ -608,40 +633,23 @@
 			<key>name</key>
 			<string>source.ruby.embedded.html</string>
 		</dict>
-		<key>normal-html-tag</key>
+		<key>root-class-id-tag</key>
 		<dict>
-			<key>begin</key>
-			<string>([\w.#_-]+)=(?!\s)(true|false|nil)?(?=\(|\{)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.attribute-name.event.slim</string>
+					<string>punctuation.separator.key-value.html</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>constant.language.slim</string>
+					<string>entity.other.attribute-name.html</string>
 				</dict>
 			</dict>
-			<key>end</key>
-			<string>\}|\)|$</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#tag-stuff</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-double-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single-quoted</string>
-				</dict>
-			</array>
+			<key>match</key>
+			<string>(\.|#)([\w\d\-]+)</string>
 		</dict>
 		<key>rubyline</key>
 		<dict>
@@ -749,23 +757,40 @@
 				</dict>
 			</array>
 		</dict>
-		<key>tag-class-id-attribute</key>
+		<key>tag-attribute</key>
 		<dict>
+			<key>begin</key>
+			<string>([\w.#_-]+)=(?!\s)(true|false|nil)?(\s*\(|\{)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>punctuation.separator.key-value.html</string>
+					<string>entity.other.attribute-name.event.slim</string>
 				</dict>
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>entity.other.attribute-name.html</string>
+					<string>constant.language.slim</string>
 				</dict>
 			</dict>
-			<key>match</key>
-			<string>(\.|#)([\w\d-_]+)</string>
+			<key>end</key>
+			<string>\}|\)|$</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>include</key>
+					<string>#tag-stuff</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string-double-quoted</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#string-single-quoted</string>
+				</dict>
+			</array>
 		</dict>
 		<key>tag-stuff</key>
 		<dict>
@@ -773,7 +798,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>#normal-html-tag</string>
+					<string>#tag-attribute</string>
 				</dict>
 				<dict>
 					<key>include</key>

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -382,10 +382,6 @@
 					</array>
 				</dict>
 				<dict>
-					<key>include</key>
-					<string>#tag-class-id-attribute</string>
-				</dict>
-				<dict>
 					<key>begin</key>
 					<string>(\*\{)(?=.*\}|.*\|\s*$)</string>
 					<key>beginCaptures</key>
@@ -417,6 +413,10 @@
 							<string>#embedded-ruby</string>
 						</dict>
 					</array>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#tag-class-id-attribute</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -598,7 +598,7 @@
 		<key>normal-html-tag</key>
 		<dict>
 			<key>begin</key>
-			<string>([\w.#_-]+)=(true|false|nil)?</string>
+			<string>([\w.#_-]+)=(?!\s)(true|false|nil)?</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -655,7 +655,7 @@
 		<key>rubyline</key>
 		<dict>
 			<key>begin</key>
-			<string>(==|=)(&lt;&gt;|&gt;&lt;|&lt;'|'&lt;|&lt;|&gt;|')?|-</string>
+			<string>(==|=)(&lt;&gt;|&gt;&lt;|&lt;'|'&lt;|&lt;|&gt;)?|-</string>
 			<key>contentName</key>
 			<string>source.ruby.embedded.slim</string>
 			<key>end</key>
@@ -685,7 +685,7 @@
 		<key>string-double-quoted</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;==)"</string>
+			<string>(")(?=.*")</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -723,7 +723,7 @@
 		<key>string-single-quoted</key>
 		<dict>
 			<key>begin</key>
-			<string>(?&lt;==)'</string>
+			<string>(')(?=.*')</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -776,39 +776,6 @@
 			<key>match</key>
 			<string>(\.|#)([\w\d-_]+)</string>
 		</dict>
-		<key>tag-id-attribute</key>
-		<dict>
-			<key>begin</key>
-			<string>\b(id)\b\s*(=)</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>entity.other.attribute-name.id.html</string>
-				</dict>
-				<key>2</key>
-				<dict>
-					<key>name</key>
-					<string>punctuation.separator.key-value.html</string>
-				</dict>
-			</dict>
-			<key>end</key>
-			<string>(?&lt;='|")</string>
-			<key>name</key>
-			<string>meta.attribute-with-value.id.html</string>
-			<key>patterns</key>
-			<array>
-				<dict>
-					<key>include</key>
-					<string>#string-double-quoted</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#string-single-quoted</string>
-				</dict>
-			</array>
-		</dict>
 		<key>tag-stuff</key>
 		<dict>
 			<key>patterns</key>
@@ -816,10 +783,6 @@
 				<dict>
 					<key>include</key>
 					<string>#normal-html-tag</string>
-				</dict>
-				<dict>
-					<key>include</key>
-					<string>#tag-id-attribute</string>
 				</dict>
 				<dict>
 					<key>include</key>


### PR DESCRIPTION
Apologies for the massive code dump; I'll do my best to humanize the work in this PR comment.

---

## Screenshots

**Before**

![Before](http://i.imgur.com/rS5cRCW.png)

**After**

![After](http://i.imgur.com/w8OTomw.png)

## File Additions
* Converts the `.tmLanguage` to [its YAML equivalent](https://github.com/SublimeText/PackageDev#editing-existing-syntax-definitions) in `Syntaxes/Ruby Slim.YAML-tmLanguage`. This will require an extra build step, but the improved legibility is worth it.
* A sample page to visually confirm the highlighting works as intended is provided in `Demo/demo.slim`. Its contents aim to cover as many edge cases as possible.

## Features
* Added filters for `erb:` and `less:`
* Definitions for initial selectors (`.` or `#` [shortcuts](https://github.com/slim-template/slim#id-shortcut--and-class-shortcut-) or HTML tags like `span`)
* Definitions for `.` and `#` shortcut separators (i.e. span`.`my-class`#`my-id)
* Definitions for attributes (i.e. a.`my-class`#`my-id` `href`="#")
* Definitions for constants `true`, `false`, and `nil` when used as attribute values
* Definitions for [splats](https://github.com/slim-template/slim#splat-attributes-) (i.e. a `*{`href: '#'`}`)
* Definitions for inline tags (i.e. p`:` span.my-new-tag)

## Bugfixes
* Support for the [bracket attribute wrapper](https://github.com/slim-template/slim#attributes-wrapper) (i.e. span[`attribute="value" other-attribute="other-value"`])
* #20 (related [comment](https://github.com/slim-template/ruby-slim.tmbundle/pull/37#issuecomment-71109154))
* #38 
* #47 and #53 
* #56 
* #58 

*(Unrelated: #23 and #41 seem complete)*