### PR TITLE
Fix js scope

### DIFF
--- a/Syntaxes/Ruby Slim.YAML-tmLanguage
+++ b/Syntaxes/Ruby Slim.YAML-tmLanguage
@@ -20,7 +20,7 @@ patterns:
     '2':
       name: constant.language.name.javascript.filter.slim
   end: ^(?!(\1\s)|\s*$)
-  name: text.javascript.filter.slim
+  name: source.js.filter.slim
   patterns:
   - include: source.js
 

--- a/Syntaxes/Ruby Slim.tmLanguage
+++ b/Syntaxes/Ruby Slim.tmLanguage
@@ -54,7 +54,7 @@
 			<key>end</key>
 			<string>^(?!(\1\s)|\s*$)</string>
 			<key>name</key>
-			<string>text.javascript.filter.slim</string>
+			<string>source.js.filter.slim</string>
 			<key>patterns</key>
 			<array>
 				<dict>


### PR DESCRIPTION
With this fix we can use JS snippets inside `javascript:` filters.